### PR TITLE
Enable borderless windowed mode on all non-windows platforms

### DIFF
--- a/.run/Publish Pong.Desktop to folder (Linux).run.xml
+++ b/.run/Publish Pong.Desktop to folder (Linux).run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Pong.Desktop to folder (Linux)" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" ready_to_run="true" runtime="linux-x64" self_contained="true" target_folder="$PROJECT_DIR$/Pong.Desktop/bin/Release/net8.0/linux-x64/publish" target_framework="net8.0" trim_unused_assemblies="true" uuid_high="-5622673001972939235" uuid_low="-8418594028265780311" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/Pong.Game.Shared/Game1.cs
+++ b/Pong.Game.Shared/Game1.cs
@@ -87,8 +87,8 @@ namespace Pong.Game
             _graphics.HardwareModeSwitch = false;
 #endif
             
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                _graphics.HardwareModeSwitch = false; // Force borderless window on Mac
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                _graphics.HardwareModeSwitch = false; // Force borderless window on Mac & Linux
             
             _graphics.ApplyChanges();
 


### PR DESCRIPTION
Makes the game work better with DEs. Since the game is so small, it shouldn't make it slower on 99.9% of devices (on the 0.1% I'd be surprised if .NET even ran)