### PR TITLE
Only allow bot mode change when game is not started

### DIFF
--- a/Pong.Game.Shared/Game1.cs
+++ b/Pong.Game.Shared/Game1.cs
@@ -302,7 +302,7 @@ namespace Pong.Game
                 || plr2GamepadState.IsButtonDown(Buttons.Start))
                 Restart();
 
-            if (!_botButtonDown
+            if (!_botButtonDown && !_gameStarted
                 && (keyboard.IsKeyDown(Keys.B)
                     || plr1GamepadState.IsButtonDown(Buttons.Y)
                     || plr2GamepadState.IsButtonDown(Buttons.Y)))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents switching to/from bot mode during an active game; the toggle now only works before a round starts.
  - Reduces accidental mode changes from keyboard or gamepad inputs mid-play, improving control consistency.
  - Enhances gameplay stability by ensuring bot mode is set during pre-game setup rather than interrupting ongoing matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->